### PR TITLE
Adding Trend Allocation howto video

### DIFF
--- a/docs/how_to_videos/plan/trend-allocation.mdx
+++ b/docs/how_to_videos/plan/trend-allocation.mdx
@@ -1,0 +1,19 @@
+---
+id: trend-allocation
+title: Trend Allocation
+sidebar_label: Trend Allocation
+---
+import useBaseUrl from '@docusaurus/useBaseUrl'; // Add to the top of the file below the front matter.
+import { Vimeo } from '@site/src/components/Vimeo';
+
+If you have to re-budget or re-forecast with aggressive growth plans, use this allocation method for instantly spreading the values using your desired Trend across period.
+
+<Vimeo
+    video="https://player.vimeo.com/video/448043166"
+    responsive={true}
+/>
+
+
+
+
+

--- a/sidebars.js
+++ b/sidebars.js
@@ -82,9 +82,11 @@ module.exports = {
                 type: "category",
                 label: "Plan",
                 items: ["how_to_videos/plan/data-series",
-            "how_to_videos/plan/planning-toolbar",
-        "how_to_videos/plan/allocate-by-weight",
-    "how_to_videos/plan/equal-allocation"]
+                        "how_to_videos/plan/planning-toolbar",
+                        "how_to_videos/plan/allocate-by-weight",
+                        "how_to_videos/plan/equal-allocation",
+                        "how_to_videos/plan/trend-allocation"
+]
 
             },
             {


### PR DESCRIPTION
Moving the *Trend Allocation* howto video from [Staging](https://staging.docs.valq.com/) to [Production](https://docs.valq.com/).

- Appended the sidebars.js file with the new section file ids.

/assign @vbisrikkanth @praveenn-vbi 