### PR TITLE
Adding Copy Allocation method under Plan how to videos section

### DIFF
--- a/docs/how_to_videos/plan/copy-allocation.mdx
+++ b/docs/how_to_videos/plan/copy-allocation.mdx
@@ -1,0 +1,18 @@
+---
+id: copy-allocation
+title: Copy Allocation
+sidebar_label: Copy Allocation
+---
+import useBaseUrl from '@docusaurus/useBaseUrl'; // Add to the top of the file below the front matter.
+import { Vimeo } from '@site/src/components/Vimeo';
+
+Use this allocation method of copying the value across all periods when you expect the same value repeat every time.
+<Vimeo
+    video="https://player.vimeo.com/video/452093826"
+    responsive={true}
+/>
+
+
+
+
+

--- a/sidebars.js
+++ b/sidebars.js
@@ -82,7 +82,8 @@ module.exports = {
                         "how_to_videos/plan/planning-toolbar",
                         "how_to_videos/plan/allocate-by-weight",
                         "how_to_videos/plan/equal-allocation",
-                        "how_to_videos/plan/trend-allocation"
+                        "how_to_videos/plan/trend-allocation",
+                        "how_to_videos/plan/copy-allocation"
 ]
 
             },


### PR DESCRIPTION
Moving the [page](https://staging.docs.valq.com/docs/how_to_videos/plan/copy-allocation) from Staging to Production.

/assign @vbisrikkanth 